### PR TITLE
Remove use of WINDOW_PROVIDERS

### DIFF
--- a/src/window/window.spec.ts
+++ b/src/window/window.spec.ts
@@ -3,7 +3,7 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 
 import {setupComponentTestingModule} from '../testing/test-lib';
 
-import {WINDOW, WINDOW_PROVIDERS} from './window';
+import {browserWindowProvider, WINDOW, windowProvider} from './window';
 
 @Component({
   selector: 'ph-window-test-host',
@@ -29,7 +29,8 @@ function setupWindowTestingModule(platformType: PlatformType) {
         provide: PLATFORM_ID,
         useValue: platformType,
       },
-      ...WINDOW_PROVIDERS,
+      browserWindowProvider,
+      windowProvider,
     ],
   })
   class MockWindowModule {}

--- a/src/window/window.ts
+++ b/src/window/window.ts
@@ -31,21 +31,19 @@ export function windowFactory(
   }
 }
 
-const browserWindowProvider: ClassProvider = {
+export const browserWindowProvider: ClassProvider = {
   provide: WindowRef,
   useClass: BrowserWindowRef,
 };
 
-const windowProvider: FactoryProvider = {
+export const windowProvider: FactoryProvider = {
   provide: WINDOW,
   useFactory: windowFactory,
   deps: [WindowRef, PLATFORM_ID],
 };
 
-export const WINDOW_PROVIDERS = [browserWindowProvider, windowProvider];
-
 @NgModule({
-  providers: [...WINDOW_PROVIDERS],
+  providers: [browserWindowProvider, windowProvider],
 })
 export class WindowModule {
 }


### PR DESCRIPTION
Seems to cause warnings when used like it was and potentially
compatibility issues with angular v11+